### PR TITLE
Version 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,16 +15,16 @@ matrix:
 script:
   - |
     cd $CRATE
-    if [ -z "$FEATURES" ]; then
-      cargo build --verbose &&
-      cargo test --verbose
+    if [ -z "$FEATURES" ] || [ "$FEATURES" = runtime ]; then
+      cargo build --verbose --no-default-features --features=$FEATURES &&
+      cargo test --verbose --no-default-features --features=$FEATURES
     else
-      cargo check --verbose --features=$FEATURES
+      cargo check --verbose --no-default-features --features=$FEATURES
     fi
 env:
-  - CRATE=twitter-stream
-#  - CRATE=twitter-stream FEATURES=tls-rustls
-  - CRATE=twitter-stream FEATURES=tls-openssl
-  - CRATE=twitter-stream FEATURES=egg-mode
-  - CRATE=twitter-stream FEATURES=tweetust
+  - CRATE=twitter-stream FEATURES=runtime
+  - CRATE=twitter-stream FEATURES=runtime,tls
+#  - CRATE=twitter-stream FEATURES=runtime,tls-rustls
+  - CRATE=twitter-stream FEATURES=runtime,tls-openssl
+  - CRATE=twitter-stream FEATURES=runtime,egg-mode,tweetust
   - CRATE=twitter-stream-message

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,5 +6,5 @@ members = [
 ]
 
 [replace]
-"twitter-stream:0.5.3" = { path = "twitter-stream" }
+"twitter-stream:0.6.0-alpha" = { path = "twitter-stream" }
 "twitter-stream-message:0.3.0" = { path = "twitter-stream-message" }

--- a/README.md
+++ b/README.md
@@ -28,20 +28,15 @@ extern crate twitter_stream;
 Here is a basic example that prints public mentions @Twitter in JSON format:
 
 ```rust
-extern crate futures;
-extern crate tokio_core;
 extern crate twitter_stream;
 
-use futures::{Future, Stream};
-use tokio_core::reactor::Core;
 use twitter_stream::{Token, TwitterStreamBuilder};
+use twitter_stream::rt::{self, Future, Stream};
 
 fn main() {
     let token = Token::new("consumer_key", "consumer_secret", "access_key", "access_secret");
 
-    let mut core = Core::new().unwrap();
-
-    let future = TwitterStreamBuilder::filter(&token).handle(&core.handle())
+    let future = TwitterStreamBuilder::filter(&token)
         .replies(true)
         .track(Some("@Twitter"))
         .listen()
@@ -49,8 +44,9 @@ fn main() {
         .for_each(|json| {
             println!("{}", json);
             Ok(())
-        });
+        })
+        .map_err(|e| println!("error: {}", e));
 
-    core.run(future).unwrap();
+    rt::run(future);
 }
 ```

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -33,7 +33,7 @@ native-tls = { version = "0.1", optional = true }
 oauthcli = { version = "1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 tweetust = { version = "0.8", optional = true }
-twitter-stream-message = { version = "0.2", optional = true }
+twitter-stream-message = { version = "0.3", optional = true }
 
 [dev-dependencies]
 base64 = "0.9"

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -25,7 +25,6 @@ percent-encoding = "1"
 rand = "0.5"
 sha-1 = "0.7"
 tokio-core = "0.1"
-url = "1"
 egg-mode = { version = "0.8", optional = true }
 hyper-openssl = { version = "0.3", optional = true }
 # hyper-rustls = { version = "0.7", optional = true }

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -14,12 +14,16 @@ A library for listening on Twitter Streaming API.
 """
 
 [dependencies]
+byteorder = { version = "1.2.3", features = ["i128"] }
 bytes = "0.4.4"
 cfg-if = "0.1"
 futures = "0.1.4"
+hmac = "0.6"
 hyper = "0.11"
 lazy_static = "1"
-oauthcli = "1"
+percent-encoding = "1"
+rand = "0.5"
+sha-1 = "0.7"
 tokio-core = "0.1"
 url = "1"
 egg-mode = { version = "0.8", optional = true }
@@ -30,6 +34,9 @@ native-tls = { version = "0.1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 tweetust = { version = "0.8", optional = true }
 twitter-stream-message = { version = "0.2", optional = true }
+
+[dev-dependencies]
+base64 = "0.9"
 
 [features]
 default = ["tls"]

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -27,8 +27,7 @@ hyper-openssl = { version = "0.3", optional = true }
 # hyper-rustls = { version = "0.7", optional = true }
 hyper-tls = { version = "0.1", optional = true }
 native-tls = { version = "0.1", optional = true }
-serde = { version = "1", optional = true }
-serde_derive = { version = "1", optional = true }
+serde = { version = "1", optional = true, features = ["derive"] }
 tweetust = { version = "0.8", optional = true }
 twitter-stream-message = { version = "0.2", optional = true }
 
@@ -38,4 +37,3 @@ parse = ["twitter-stream-message"]
 tls = ["hyper-tls", "native-tls"]
 tls-openssl = ["hyper-openssl"]
 # tls-rustls = ["hyper-rustls"]
-use-serde = ["serde", "serde_derive"]

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -19,16 +19,16 @@ bytes = "0.4.4"
 cfg-if = "0.1"
 futures = "0.1.4"
 hmac = "0.6"
-hyper = "0.11"
-lazy_static = "1"
+hyper = "0.12"
 percent-encoding = "1"
 rand = "0.5"
 sha-1 = "0.7"
-tokio-core = "0.1"
+tokio = "0.1"
+tokio-timer = "0.2"
 egg-mode = { version = "0.12", optional = true }
-hyper-openssl = { version = "0.3", optional = true }
-hyper-rustls = { version = "0.12", optional = true }
-hyper-tls = { version = "0.1", optional = true }
+hyper-openssl = { version = "0.6", optional = true }
+# hyper-rustls = { version = "0.12", optional = true }
+hyper-tls = { version = "0.2", optional = true }
 native-tls = { version = "0.1", optional = true }
 oauthcli = { version = "1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
@@ -39,9 +39,12 @@ twitter-stream-message = { version = "0.2", optional = true }
 base64 = "0.9"
 
 [features]
-default = ["tls"]
+default = ["runtime", "tls"]
 parse = ["twitter-stream-message"]
+# `runtime` feature does nothing useful for now, but this feature is
+# necessary for the crate to compile, leaving possibility for future extension.
+runtime = ["hyper/runtime"]
 tls = ["hyper-tls", "native-tls"]
 tls-openssl = ["hyper-openssl"]
-tls-rustls = ["hyper-rustls"]
+# tls-rustls = ["hyper-rustls"]
 use-tweetust = ["oauthcli", "tweetust"]

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -33,7 +33,7 @@ tweetust = { version = "0.8", optional = true }
 twitter-stream-message = { version = "0.2", optional = true }
 
 [features]
-default = ["parse", "tls", "use-serde"]
+default = ["tls"]
 parse = ["twitter-stream-message"]
 tls = ["hyper-tls", "native-tls"]
 tls-openssl = ["hyper-openssl"]

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "twitter-stream"
-version = "0.5.3"
+version = "0.6.0-alpha"
 authors = ["Daiki Mizukami <mizukami1113@gmail.com>"]
 license = "MIT"
 readme = "../README.md"

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -30,6 +30,7 @@ hyper-openssl = { version = "0.3", optional = true }
 hyper-rustls = { version = "0.12", optional = true }
 hyper-tls = { version = "0.1", optional = true }
 native-tls = { version = "0.1", optional = true }
+oauthcli = { version = "1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 tweetust = { version = "0.8", optional = true }
 twitter-stream-message = { version = "0.2", optional = true }
@@ -43,3 +44,4 @@ parse = ["twitter-stream-message"]
 tls = ["hyper-tls", "native-tls"]
 tls-openssl = ["hyper-openssl"]
 tls-rustls = ["hyper-rustls"]
+use-tweetust = ["oauthcli", "tweetust"]

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -25,7 +25,7 @@ percent-encoding = "1"
 rand = "0.5"
 sha-1 = "0.7"
 tokio-core = "0.1"
-egg-mode = { version = "0.8", optional = true }
+egg-mode = { version = "0.12", optional = true }
 hyper-openssl = { version = "0.3", optional = true }
 hyper-rustls = { version = "0.12", optional = true }
 hyper-tls = { version = "0.1", optional = true }

--- a/twitter-stream/Cargo.toml
+++ b/twitter-stream/Cargo.toml
@@ -27,7 +27,7 @@ sha-1 = "0.7"
 tokio-core = "0.1"
 egg-mode = { version = "0.8", optional = true }
 hyper-openssl = { version = "0.3", optional = true }
-# hyper-rustls = { version = "0.7", optional = true }
+hyper-rustls = { version = "0.12", optional = true }
 hyper-tls = { version = "0.1", optional = true }
 native-tls = { version = "0.1", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
@@ -42,4 +42,4 @@ default = ["tls"]
 parse = ["twitter-stream-message"]
 tls = ["hyper-tls", "native-tls"]
 tls-openssl = ["hyper-openssl"]
-# tls-rustls = ["hyper-rustls"]
+tls-rustls = ["hyper-rustls"]

--- a/twitter-stream/src/auth.rs
+++ b/twitter-stream/src/auth.rs
@@ -19,7 +19,7 @@ use types::RequestMethod;
 This implements `tweetust::conn::Authenticator` so you can pass it to
 `tweetust::TwitterClient` as if it were `tweetust::OAuthAuthenticator`"
 )]
-#[cfg_attr(feature = "use-serde", derive(Deserialize, Serialize))]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[derive(Clone, Debug)]
 pub struct Token<'a> {
     pub consumer_key: Cow<'a, str>,

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -60,11 +60,9 @@ extern crate hyper;
 #[macro_use]
 extern crate lazy_static;
 extern crate oauthcli;
-#[cfg(feature = "use-serde")]
-extern crate serde;
-#[cfg(feature = "use-serde")]
+#[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 extern crate tokio_core;
 #[cfg(feature = "parse")]
 extern crate twitter_stream_message;

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -786,3 +786,31 @@ cfg_if! {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_dictionary_order() {
+        TwitterStreamBuilder {
+            client_or_handle: &(),
+            method: RequestMethod::Get,
+            endpoint: &EP_FILTER,
+            token: &Token::new("", "", "", ""),
+            timeout: None,
+            stall_warnings: true,
+            filter_level: FilterLevel::Low,
+            language: Some("en"),
+            follow: Some(&[12]),
+            track: Some("\"User Stream\" to:TwitterDev"),
+            locations: Some(&[((37.7748, -122.4146), (37.7788, -122.4186))]),
+            count: Some(10),
+            with: Some(With::User),
+            replies: true,
+            user_agent: None,
+        }.build_query(QueryBuilder::new_form("", "", "", ""));
+        // `QueryBuilder::check_dictionary_order` will panic
+        // if the insertion order of query pairs is incorrect.
+    }
+}

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -230,15 +230,6 @@ macro_rules! def_stream {
                 }
             )*
 
-            /// Set a user agent string to be sent when connectiong to
-            /// the Stream.
-            pub fn user_agent<T>(&mut self, user_agent: Option<T>) -> &mut Self
-                where T: Into<Cow<'static, str>>
-            {
-                self.user_agent = user_agent.map(Into::into);
-                self
-            }
-
             $(
                 $(#[$setter_attr])*
                 pub fn $setter(&mut self, $setter: $s_ty) -> &mut Self {
@@ -251,6 +242,16 @@ macro_rules! def_stream {
             #[deprecated(since = "0.6.0", note = "Use `endpoint` instead")]
             pub fn end_point(&mut self, end_point: &'a Uri) -> &mut Self {
                 self.endpoint = end_point;
+                self
+            }
+
+            /// Set a user agent string to be sent when connectiong to
+            /// the Stream.
+            #[deprecated(since = "0.6.0", note = "Will be removed in 0.7")]
+            pub fn user_agent<T>(&mut self, user_agent: Option<T>) -> &mut Self
+                where T: Into<Cow<'static, str>>
+            {
+                self.user_agent = user_agent.map(Into::into);
                 self
             }
         }

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -74,9 +74,18 @@ extern crate url;
 mod util;
 
 pub mod error;
-#[cfg(feature = "parse")]
-pub mod message;
 pub mod types;
+
+/// Exports `twitter_stream_message` crate for convenience.
+/// This module requires `parse` feature flag to be enabled.
+#[cfg(feature = "parse")]
+#[deprecated(
+    since = "0.6.0",
+    note = "use `extern crate twitter_stream_message;` instead",
+)]
+pub mod message {
+    pub use twitter_stream_message::*;
+}
 
 mod auth;
 

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -96,7 +96,6 @@ pub use error::Error;
 
 use std::borrow::{Borrow, Cow};
 use std::fmt::{self, Display, Formatter};
-use std::ops::Deref;
 use std::time::Duration;
 
 use futures::{Future, Poll, Stream};
@@ -166,7 +165,7 @@ macro_rules! def_stream {
                 pub fn $constructor(token: &$lifetime Token<C, A>) -> Self {
                     $B::custom(
                         RequestMethod::$Method,
-                        $endpoint.deref(),
+                        &*$endpoint,
                         token,
                     )
                 }

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -249,6 +249,7 @@ macro_rules! def_stream {
         impl $S {
             $(
                 $(#[$s_constructor_attr])*
+                #[allow(deprecated)]
                 pub fn $constructor(token: &Token, handle: &Handle) -> $FS {
                     $B::$constructor(token).handle(handle).listen()
                 }
@@ -436,8 +437,16 @@ def_stream! {
     /// See the [Twitter Developer Documentation][1] for more information.
     ///
     /// [1]: https://dev.twitter.com/streaming/reference/get/user
+    #[deprecated(
+        since = "0.6.0",
+        note = "The User stream has been deprecated and will be unavailable",
+    )]
     -
     /// A shorthand for `TwitterStreamBuilder::user().listen()`.
+    #[deprecated(
+        since = "0.6.0",
+        note = "The User stream has been deprecated and will be unavailable",
+    )]
     pub fn user(Get, EP_USER);
 }
 

--- a/twitter-stream/src/lib.rs
+++ b/twitter-stream/src/lib.rs
@@ -175,7 +175,7 @@ macro_rules! def_stream {
                 }
             )*
 
-            /// Constructs a builder for a Stream at a custom end point.
+            /// Constructs a builder for a Stream at a custom endpoint.
             pub fn custom($($arg: $a_ty),*) -> $B<$lifetime, ()> {
                 $B {
                     $client_or_handle: $ch_default,
@@ -246,6 +246,13 @@ macro_rules! def_stream {
                     self
                 }
             )*
+
+            /// Reset the API endpoint URI to be connected.
+            #[deprecated(since = "0.6.0", note = "Use `endpoint` instead")]
+            pub fn end_point(&mut self, end_point: &'a Uri) -> &mut Self {
+                self.endpoint = end_point;
+                self
+            }
         }
 
         impl $S {
@@ -313,7 +320,7 @@ def_stream! {
         method: RequestMethod,
 
         /// Reset the API endpoint URI to be connected.
-        end_point: &'a Uri,
+        endpoint: &'a Uri,
 
         /// Reset the token to be used to log into Twitter.
         token: &'a Token<'a>;
@@ -502,7 +509,7 @@ impl<'a> TwitterStreamBuilder<'a, Handle> {
 }
 
 impl<'a, _CH> TwitterStreamBuilder<'a, _CH> {
-    /// Make an HTTP connection to an end point of the Streaming API.
+    /// Make an HTTP connection to an endpoint of the Streaming API.
     fn connect<C, B>(&self, c: &Client<C, B>) -> FutureResponse
     where
         C: Connect,
@@ -520,7 +527,7 @@ impl<'a, _CH> TwitterStreamBuilder<'a, _CH> {
 
             let query = QueryBuilder::new_form(
                 &*self.token.consumer_secret, &*self.token.access_secret,
-                "POST", self.end_point.as_ref(),
+                "POST", self.endpoint.as_ref(),
             );
             let QueryOutcome { header, query } = self.build_query(query);
 
@@ -530,7 +537,7 @@ impl<'a, _CH> TwitterStreamBuilder<'a, _CH> {
 
             let mut req = Request::new(
                 RequestMethod::Post,
-                self.end_point.clone(),
+                self.endpoint.clone(),
             );
             *req.headers_mut() = headers;
             req.set_body(query.into_bytes());
@@ -547,7 +554,7 @@ impl<'a, _CH> TwitterStreamBuilder<'a, _CH> {
                     },
                     ref m => m.as_ref(),
                 },
-                self.end_point.as_ref().to_owned(),
+                self.endpoint.as_ref().to_owned(),
             );
             let QueryOutcome { header, query: uri } = self.build_query(query);
 

--- a/twitter-stream/src/message.rs
+++ b/twitter-stream/src/message.rs
@@ -1,4 +1,0 @@
-//! Exports `twitter_stream_message` crate for convenience.
-//! This module requires `parse` feature flag to be enabled.
-
-pub use twitter_stream_message::*;

--- a/twitter-stream/src/query_builder.rs
+++ b/twitter-stream/src/query_builder.rs
@@ -1,0 +1,446 @@
+use std::borrow::Cow;
+use std::fmt::{self, Display, Formatter, Write};
+use std::str;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use byteorder::{BigEndian, ByteOrder};
+use hmac::{Hmac, Mac};
+use percent_encoding::{EncodeSet as EncodeSet_, PercentEncode};
+use rand::thread_rng;
+use rand::distributions::{Alphanumeric, Distribution};
+use sha1::Sha1;
+
+/// Builds URI query / x-www-form-urlencoded string and OAuth header string.
+pub struct QueryBuilder {
+    header: String,
+    query: String,
+    mac: MacWrite<Hmac<Sha1>>,
+    will_append_question_mark: bool,
+}
+
+pub struct QueryOutcome {
+    pub header: String,
+    pub query: String,
+}
+
+struct Base64PercentEncode<'a>(&'a [u8]);
+
+struct DoublePercentEncode<'a>(&'a str);
+
+struct MacWrite<M>(M);
+
+// https://tools.ietf.org/html/rfc3986#section-2.1
+#[derive(Clone)]
+struct EncodeSet;
+
+impl QueryBuilder {
+    pub fn new(cs: &str, as_: &str, method: &str, uri: String) -> Self {
+        Self::new_(cs, as_, method, Cow::Owned(uri))
+    }
+
+    pub fn new_form(cs: &str, as_: &str, method: &str, uri: &str) -> Self {
+        Self::new_(cs, as_, method, Cow::Borrowed(uri))
+    }
+
+    fn new_(cs: &str, as_: &str, method: &str, uri: Cow<str>)
+        -> Self
+    {
+        let standard_header_len = str::len(r#"\
+            OAuth \
+            oauth_consumer_key="XXXXXXXXXXXXXXXXXXXXXXXXX",\
+            oauth_nonce="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",\
+            oauth_signature_method="HMAC-SHA1",\
+            oauth_timestamp="NNNNNNNNNN",\
+            oauth_token="NNNNNNNNNNNNNNNNNNN-\
+                XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",\
+            oauth_version="1.0",\
+            oauth_signature="\
+                %XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX\
+                %XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX%XX"\
+        "#);
+
+        let mut header = String::with_capacity(standard_header_len);
+        header.push_str("OAuth ");
+
+        let mut signing_key = String::with_capacity(
+            3 * (cs.len() + as_.len()) + 1
+        );
+        write!(signing_key, "{}&{}", percent_encode(cs), percent_encode(as_))
+            .unwrap();
+        let mut mac = MacWrite(Hmac::new_varkey(signing_key.as_bytes()).unwrap());
+
+        let query;
+        let will_append_question_mark;
+        {
+            let uri = match uri {
+                Cow::Borrowed(u) => { // x-www-form-urlencoded
+                    query = String::new();
+                    will_append_question_mark = false;
+                    u
+                },
+                Cow::Owned(u) => { // URI query
+                    query = u;
+                    will_append_question_mark = true;
+                    &query
+                },
+            };
+            write!(mac, "{}&{}&", method, percent_encode(uri))
+                .unwrap();
+        }
+
+        QueryBuilder { header, query, mac, will_append_question_mark }
+    }
+
+    pub fn append(&mut self, k: &str, v: &str, end: bool) {
+        self.append_question_mark();
+        write!(self.query, "{}={}", k, percent_encode(v)).unwrap();
+        self.mac_input(k, v, end);
+        if ! end { self.query.push('&'); }
+    }
+
+    /// `v` is used to make query string and `w` is used to make the signature.
+    /// `v` should be percent encoded and `w` should be percent encoded twice.
+    pub fn append_encoded<V, W>(&mut self, k: &str, v: V, w: W, end: bool)
+        where V: Display, W: Display
+    {
+        self.append_question_mark();
+        write!(self.query, "{}={}", k, v).unwrap();
+        self.mac_input_encoded(k, w, end);
+        if ! end { self.query.push('&'); }
+    }
+
+    pub fn append_oauth_params(&mut self, ck: &str, ak: &str, end: bool) {
+        let nonce = Alphanumeric.sample_iter(&mut thread_rng())
+            .take(32)
+            .collect::<String>();
+        let timestamp = match SystemTime::now().duration_since(UNIX_EPOCH) {
+            Ok(d) => d.as_secs(),
+            #[cold] Err(_) => 0,
+        };
+        self.append_oauth_params_(ck, ak, &nonce, timestamp, end);
+    }
+
+    fn append_oauth_params_(
+        &mut self,
+        ck: &str,
+        ak: &str,
+        nonce: &str,
+        timestamp: u64,
+        end: bool,
+    ) {
+        self.append_question_mark();
+        self.append_to_header("oauth_consumer_key", ck, false);
+        self.append_to_header_encoded("oauth_nonce", &*nonce, false);
+        self.append_to_header_encoded(
+            "oauth_signature_method", "HMAC-SHA1", false
+        );
+        self.append_to_header_encoded("oauth_timestamp", timestamp, false);
+        self.append_to_header("oauth_token", ak, false);
+        self.append_to_header_encoded("oauth_version", "1.0", end);
+    }
+
+    fn append_to_header(&mut self, k: &str, v: &str, end: bool) {
+        write!(self.header, r#"{}="{}","#, k, percent_encode(v)).unwrap();
+        self.mac_input(k, v, end);
+    }
+
+    fn append_to_header_encoded<V: Display>(&mut self, k: &str, v: V, end: bool)
+    {
+        write!(self.header, r#"{}="{}","#, k, v).unwrap();
+        self.mac_input_encoded(k, v, end);
+    }
+
+    fn append_question_mark(&mut self) {
+        if self.will_append_question_mark {
+            self.query.push('?');
+            self.will_append_question_mark = false;
+        }
+    }
+
+    fn mac_input(&mut self, k: &str, v: &str, end: bool) {
+        write!(self.mac, "{}%3D{}", k, DoublePercentEncode(v)).unwrap();
+        if ! end { self.mac.write_str("%26").unwrap(); }
+    }
+
+    fn mac_input_encoded<V: Display>(&mut self, k: &str, v: V, end: bool) {
+        write!(self.mac, "{}%3D{}", k, v).unwrap();
+        if ! end { self.mac.write_str("%26").unwrap(); }
+    }
+
+    pub fn build(mut self) -> QueryOutcome {
+        let s = self.mac.0.result().code();
+        write!(self.header, r#"oauth_signature="{}""#, Base64PercentEncode(&s))
+            .unwrap();
+        let QueryBuilder { header, query, .. } = self;
+        QueryOutcome { header, query }
+    }
+}
+
+impl<'a> Display for Base64PercentEncode<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        const ENCODE: [&str; 0b0100_0000] = [
+            "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+            "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+            "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
+            "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+            "%2B", "%2F",
+        ];
+
+        assert_eq!(self.0.len(), 20);
+
+        macro_rules! write_enc {
+            ($bytes:expr, $shl:expr) => {{
+                f.write_str(ENCODE[(($bytes >> $shl) & 0b11_1111) as usize])?;
+            }};
+        }
+
+        let bytes = BigEndian::read_u128(self.0);
+        for i in 0..16 {
+            write_enc!(bytes, 128 - 6 - 6 * i);
+        }
+        let bytes = BigEndian::read_u64(&self.0[12..20]);
+        for i in 0..10 {
+            write_enc!(bytes, 64 - 6 - 6 * i);
+        }
+        f.write_str(ENCODE[((bytes << 2) & 0b11_1111) as usize])?;
+
+        // '='
+        f.write_str("%3D")
+    }
+}
+
+impl<'a> Display for DoublePercentEncode<'a> {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut bytes = self.0.as_bytes();
+        while let Some((&b, rem)) = bytes.split_first() {
+            if EncodeSet.contains(b) {
+                f.write_str(double_encode_byte(b))?;
+                bytes = rem;
+                continue;
+            }
+
+            // Write as much characters as possible at once:
+            if let Some((i, &b)) = bytes.iter().enumerate().skip(1)
+                .find(|&(_, &b)| EncodeSet.contains(b))
+            {
+                let rem = &bytes[i+1..];
+                let s = &bytes[..i];
+                debug_assert!(s.is_ascii());
+                f.write_str(unsafe { str::from_utf8_unchecked(s)})?;
+                f.write_str(double_encode_byte(b))?;
+                bytes = rem;
+            } else {
+                debug_assert!(bytes.is_ascii());
+                return f.write_str(unsafe { str::from_utf8_unchecked(bytes) });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn double_encode_byte(b: u8) -> &'static str {
+    const ENCODE: &[u8; 0x100*5] = b"\
+        %2500%2501%2502%2503%2504%2505%2506%2507\
+        %2508%2509%250A%250B%250C%250D%250E%250F\
+        %2510%2511%2512%2513%2514%2515%2516%2517\
+        %2518%2519%251A%251B%251C%251D%251E%251F\
+        %2520%2521%2522%2523%2524%2525%2526%2527\
+        %2528%2529%252A%252B%252C%252D%252E%252F\
+        %2530%2531%2532%2533%2534%2535%2536%2537\
+        %2538%2539%253A%253B%253C%253D%253E%253F\
+        %2540%2541%2542%2543%2544%2545%2546%2547\
+        %2548%2549%254A%254B%254C%254D%254E%254F\
+        %2550%2551%2552%2553%2554%2555%2556%2557\
+        %2558%2559%255A%255B%255C%255D%255E%255F\
+        %2560%2561%2562%2563%2564%2565%2566%2567\
+        %2568%2569%256A%256B%256C%256D%256E%256F\
+        %2570%2571%2572%2573%2574%2575%2576%2577\
+        %2578%2579%257A%257B%257C%257D%257E%257F\
+        %2580%2581%2582%2583%2584%2585%2586%2587\
+        %2588%2589%258A%258B%258C%258D%258E%258F\
+        %2590%2591%2592%2593%2594%2595%2596%2597\
+        %2598%2599%259A%259B%259C%259D%259E%259F\
+        %25A0%25A1%25A2%25A3%25A4%25A5%25A6%25A7\
+        %25A8%25A9%25AA%25AB%25AC%25AD%25AE%25AF\
+        %25B0%25B1%25B2%25B3%25B4%25B5%25B6%25B7\
+        %25B8%25B9%25BA%25BB%25BC%25BD%25BE%25BF\
+        %25C0%25C1%25C2%25C3%25C4%25C5%25C6%25C7\
+        %25C8%25C9%25CA%25CB%25CC%25CD%25CE%25CF\
+        %25D0%25D1%25D2%25D3%25D4%25D5%25D6%25D7\
+        %25D8%25D9%25DA%25DB%25DC%25DD%25DE%25DF\
+        %25E0%25E1%25E2%25E3%25E4%25E5%25E6%25E7\
+        %25E8%25E9%25EA%25EB%25EC%25ED%25EE%25EF\
+        %25F0%25F1%25F2%25F3%25F4%25F5%25F6%25F7\
+        %25F8%25F9%25FA%25FB%25FC%25FD%25FE%25FF\
+    ";
+    let b = usize::from(b);
+    unsafe { str::from_utf8_unchecked(&ENCODE[b*5..(b+1)*5]) }
+}
+
+impl<M: Mac> Write for MacWrite<M> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.0.input(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl EncodeSet_ for EncodeSet {
+    fn contains(&self, b: u8) -> bool {
+        const ENCODE_MAP: [bool; 0x100] = [
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true, false, false,  true,
+            false, false, false, false, false, false, false, false,
+            false, false,  true,  true,  true,  true,  true,  true,
+             true, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+            false, false, false,  true,  true,  true,  true, false,
+             true, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+            false, false, false, false, false, false, false, false,
+            false, false, false,  true,  true,  true, false,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+             true,  true,  true,  true,  true,  true,  true,  true,
+        ];
+
+        ENCODE_MAP[usize::from(b)]
+    }
+}
+
+fn percent_encode(input: &str) -> PercentEncode<EncodeSet> {
+    ::percent_encoding::utf8_percent_encode(input, EncodeSet)
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate base64;
+
+    use percent_encoding::percent_encode_byte;
+
+    use super::*;
+
+    // These values are taken from Twitter's document:
+    // https://developer.twitter.com/en/docs/basics/authentication/guides/creating-a-signature.html
+    const CK: &str = "xvz1evFS4wEEPTGEFPHBog";
+    const CS: &str = "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw";
+    const AK: &str = "370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb";
+    const AS: &str = "LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE";
+    const NONCE: &str = "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg";
+    const TIMESTAMP: u64 = 1318622958;
+
+    #[test]
+    fn base64_percent_encode() {
+        macro_rules! test {
+            ($bin:expr) => {
+                assert_eq!(
+                    percent_encode(&base64::encode($bin))
+                        .to_string(),
+                    Base64PercentEncode($bin).to_string(),
+                )
+            };
+        }
+        test!(b"\x84+R\x99\x88~\x88v\x02\x12\xA0V\xACN\xC2\xEE\x16&\xB5I");
+        test!(b"\x00\x10\xB1\xCB=5\xDB\xEF\xBF_/\x7F2~~M\xFD>\xFF~");
+    }
+
+    #[test]
+    fn double_percent_encode() {
+        for b in 0u8..=0xFF {
+            assert_eq!(
+                double_encode_byte(b),
+                &percent_encode(percent_encode_byte(b))
+                    .to_string(),
+            );
+        }
+    }
+
+    #[test]
+    fn encode_set() {
+        for b in 0u8..=0xFF {
+            let expected = match b {
+                b'0'...b'9'
+                    | b'A'...b'Z'
+                    | b'a'...b'z'
+                    | b'-' | b'.' | b'_' | b'~' => false,
+                _ => true,
+            };
+            assert_eq!(EncodeSet.contains(b), expected,
+                "byte = {} ({:?})", b, char::from(b)
+            );
+        }
+    }
+
+    #[test]
+    fn query_builder() {
+        let method = "GET";
+        let uri = "https://stream.twitter.com/1.1/statuses/sample.json";
+        let expected_header = "\
+            OAuth \
+            oauth_consumer_key=\"xvz1evFS4wEEPTGEFPHBog\",\
+            oauth_nonce=\"kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg\",\
+            oauth_signature_method=\"HMAC-SHA1\",\
+            oauth_timestamp=\"1318622958\",\
+            oauth_token=\"370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb\",\
+            oauth_version=\"1.0\",\
+            oauth_signature=\"OGQqcy4l5xWBFX7t0DrkP5%2FD0rM%3D\"\
+        ";
+        let expected_uri = "https://stream.twitter.com/1.1/statuses/sample.json?stall_warnings=true";
+
+        let mut qb = QueryBuilder::new(CS, AS, method, uri.to_owned());
+
+        qb.append_oauth_params_(CK, AK, NONCE, TIMESTAMP, false);
+        qb.append_encoded("stall_warnings", "true", "true", true);
+
+        let QueryOutcome { header, query: uri } = qb.build();
+        assert_eq!(uri, expected_uri);
+        assert_eq!(header, expected_header);
+    }
+
+    #[test]
+    fn query_builder_form() {
+        let method = "POST";
+        let uri = "https://api.twitter.com/1.1/statuses/update.json";
+        let status = "Hello Ladies + Gentlemen, a signed OAuth request!";
+        let expected_header = "\
+            OAuth \
+            oauth_consumer_key=\"xvz1evFS4wEEPTGEFPHBog\",\
+            oauth_nonce=\"kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg\",\
+            oauth_signature_method=\"HMAC-SHA1\",\
+            oauth_timestamp=\"1318622958\",\
+            oauth_token=\"370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb\",\
+            oauth_version=\"1.0\",\
+            oauth_signature=\"hCtSmYh%2BiHYCEqBWrE7C7hYmtUk%3D\"\
+        ";
+        let expected_query = "include_entities=true&status=Hello%20Ladies%20%2B%20Gentlemen%2C%20a%20signed%20OAuth%20request%21";
+
+        let mut qb = QueryBuilder::new_form(CS, AS, method, uri);
+
+        qb.append_encoded("include_entities", "true", "true", false);
+        qb.append_oauth_params_(CK, AK, NONCE, TIMESTAMP, false);
+        qb.append("status", status, true);
+
+        let QueryOutcome { header, query } = qb.build();
+        assert_eq!(query, expected_query);
+        assert_eq!(header, expected_header);
+    }
+}

--- a/twitter-stream/src/rt.rs
+++ b/twitter-stream/src/rt.rs
@@ -1,0 +1,5 @@
+//! Some reexports from `futures` and `tokio` crates.
+
+pub use futures::{Future, Stream};
+pub use futures::future::{lazy, poll_fn};
+pub use tokio::{spawn, run};

--- a/twitter-stream/src/token.rs
+++ b/twitter-stream/src/token.rs
@@ -36,8 +36,8 @@ cfg_if! {
 
         use self::egg_mode::KeyPair;
 
-        impl<'a, C, A> From<Token<C, A>> for egg_mode::Token<'a>
-            where C: Into<Cow<'a, str>>, A: Into<Cow<'a, str>>
+        impl<'a, C, A> From<Token<C, A>> for egg_mode::Token
+            where C: Into<Cow<'static, str>>, A: Into<Cow<'static, str>>
         {
             fn from(t: Token<C, A>) -> Self {
                 egg_mode::Token::Access {

--- a/twitter-stream/src/types.rs
+++ b/twitter-stream/src/types.rs
@@ -2,7 +2,7 @@
 
 pub use hyper::Method as RequestMethod;
 pub use hyper::StatusCode;
-pub use url::Url;
+pub use hyper::Uri;
 
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;

--- a/twitter-stream/src/util.rs
+++ b/twitter-stream/src/util.rs
@@ -84,6 +84,8 @@ pub struct TimeoutStream<S> {
     inner: Option<BaseTimeout>,
 }
 
+pub struct JoinDisplay<'a, D: 'a, Sep: ?Sized+'a>(pub &'a [D], pub &'a Sep);
+
 /// A stream over the lines (delimited by CRLF) of a `Body`.
 pub struct Lines<B> where B: Stream {
     inner: Fuse<B>,
@@ -160,6 +162,21 @@ impl<S> Stream for TimeoutStream<S> where S: Stream<Error=HyperError> {
             self.inner = None;
             ret
         })
+    }
+}
+
+impl<'a, D, Sep> Display for JoinDisplay<'a, D, Sep>
+    where D: Display+'a, Sep: Display+?Sized+'a
+{
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        let mut iter = self.0.iter();
+        if let Some(d) = iter.next() {
+            Display::fmt(d, f)?;
+            for d in iter {
+                write!(f, "{}{}", self.1, d)?;
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Breaking changes:

- `parse` feature was deprecated (fc73727)
- `use-serde` is no longer a default feature (fc73727)
- User Stream-related methods was deprecated (a8a87ca)
- `TwitterStreamBuilder::custom` now accepts `hyper::Uri` instead of `&url::Url`
- `TwitterStreamBuilder::end_point` was renamed to `endpoint` (1b6cd8c)
- `tweetust` feature was renamed to `use-tweetust` (5e94abf)
- `Token` is now generic over its inner strings' type (515a60f)
- The optional `egg-mode` dependency was updated to `0.12` (e7f5890)

And, most impotantly:

- The library now uses ✨`tokio`✨ (instead of `tokio-core`) and `hyper` version ✨`0.12`✨ (990d43b)!